### PR TITLE
Add support for force-flushing and fix builder log type parameter

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 ext.publication = [:]
 ext.publication.version = [
         'major': '1',
-        'minor': '0',
+        'minor': '1',
         'patch': '0',
 ]
 ext.publication.versionName = "${publication.version.major}.${publication.version.minor}.${publication.version.patch}"

--- a/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
+++ b/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
@@ -49,7 +49,7 @@ class PureeLogger private constructor(
     private val logStore: PureeLogStore,
     private val dispatcher: CoroutineDispatcher,
     private val clock: Clock,
-    private val registeredLogs: Map<Class<out Any>, Configuration>,
+    private val registeredLogs: Map<Class<out PureeLog>, Configuration>,
     private val bufferedOutputs: List<PureeBufferedOutput>
 ) {
     private val scope: CoroutineScope = CoroutineScope(dispatcher + CoroutineExceptionHandler { _, throwable ->
@@ -199,7 +199,7 @@ class PureeLogger private constructor(
         @VisibleForTesting
         internal var clock: Clock = Clock.systemUTC()
 
-        private val configuredLogs: MutableMap<Class<out Any>, Configuration> = mutableMapOf()
+        private val configuredLogs: MutableMap<Class<out PureeLog>, Configuration> = mutableMapOf()
         private val outputIds: MutableSet<String> = mutableSetOf()
         private val bufferedOutputs: MutableList<PureeBufferedOutput> = mutableListOf()
 
@@ -210,7 +210,7 @@ class PureeLogger private constructor(
          * @param logTypes The log types of the objects on which the [PureeFilter] will be applied. If a type is included more
          * than once, the [PureeFilter] will be applied multiple times.
          */
-        fun filter(filter: PureeFilter, vararg logTypes: Class<out Any>): Builder {
+        fun filter(filter: PureeFilter, vararg logTypes: Class<out PureeLog>): Builder {
             logTypes.forEach {
                 configuredLogs.getOrPut(it, { Configuration() }).filters.add(filter)
             }
@@ -225,10 +225,7 @@ class PureeLogger private constructor(
          * [PureeOutput] should be registered and duplicates are ignored.
          * @param logTypes The log types of the objects that will be sent to the [PureeOutput].
          */
-        fun output(
-            output: PureeOutput,
-            vararg logTypes: Class<out Any>
-        ): Builder {
+        fun output(output: PureeOutput,vararg logTypes: Class<out PureeLog>): Builder {
             if (output is PureeBufferedOutput) {
                 if (output.uniqueId in outputIds) {
                     throw IllegalArgumentException("Cannot register another PureeBufferedOutput with uniqueId: ${output.uniqueId}.")

--- a/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
+++ b/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
@@ -104,6 +104,17 @@ class PureeLogger private constructor(
     }
 
     /**
+     * Force-flush all of the buffered logs regardless of the flush interval
+     */
+    fun flush() {
+        scope.launch {
+            bufferedOutputs.forEach {
+                it.flush()
+            }
+        }
+    }
+
+    /**
      * Suspends the background process that periodically emits buffered logs if a [PureeBufferedOutput] is registered
      * through [Builder]. This is called when the [Lifecycle]'s state changes to [Lifecycle.Event.ON_STOP]
      *

--- a/puree/src/main/java/com/cookpad/puree/kotlin/output/PureeBufferedOutput.kt
+++ b/puree/src/main/java/com/cookpad/puree/kotlin/output/PureeBufferedOutput.kt
@@ -156,8 +156,7 @@ abstract class PureeBufferedOutput(
      *
      * @see resume
      */
-    @VisibleForTesting
-    protected suspend fun flush() {
+    internal suspend fun flush() {
         purgeableAge?.let {
             logStore.purgeLogsWithAge(uniqueId, Instant.now(clock), it)
         }

--- a/puree/src/test/java/com/cookpad/puree/kotlin/PureeLoggerTest.kt
+++ b/puree/src/test/java/com/cookpad/puree/kotlin/PureeLoggerTest.kt
@@ -6,6 +6,7 @@ import com.cookpad.puree.kotlin.output.PureeOutput
 import com.cookpad.puree.kotlin.rule.LifecycleCoroutineRule
 import com.cookpad.puree.kotlin.store.PureeLogStore
 import io.mockk.MockKAnnotations
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.impl.annotations.MockK
@@ -127,6 +128,31 @@ class PureeLoggerTest {
             bufferedOutput.resume()
             bufferedOutput.suspend()
             bufferedOutput.resume()
+        }
+    }
+
+    @Test
+    fun flush() {
+        // given
+        val outputs = (1..5).toList().map { index ->
+            mockk<PureeBufferedOutput>(relaxed = true) {
+                every { uniqueId } returns "buffered_output_$index"
+            }
+        }
+        val puree = createPureeBuilder().apply {
+            outputs.forEach {
+                output(it, SampleLog::class.java)
+            }
+        }.build()
+
+        // when
+        puree.flush()
+
+        // then
+        coVerifyOrder {
+            outputs.forEach {
+                it.flush()
+            }
         }
     }
 


### PR DESCRIPTION
* There are some use-cases where it's ideal to flush the buffered outputs (e.g. app launch, debugging, etc.) so I added  `PureeLogger#flush()` 0c5ad4d
* `Builder#filter()` and `Builder#output()` both accept log types of type `Class<out Any>` so I fixed it to be specific: `Class<out PureeLog>` 5c013ae