### PR TITLE
Revert "Add logType method to PureeLogger"

### DIFF
--- a/demo/src/main/java/com/cookpad/puree/kotlin/demo/DemoApp.kt
+++ b/demo/src/main/java/com/cookpad/puree/kotlin/demo/DemoApp.kt
@@ -41,23 +41,19 @@ class DemoApp : Application() {
         )
             .filter(
                 AddTimeFilter(),
-                ClickLog::class.java, MenuLog::class.java
+                ClickLog::class.java, MenuLog::class.java, PeriodicLog::class.java
             )
             .output(
                 LogcatOutput(),
-                ClickLog::class.java, MenuLog::class.java
+                ClickLog::class.java, MenuLog::class.java, PeriodicLog::class.java
             )
             .output(
                 LogcatDebugBufferedOutput("logcat_debug"),
                 ClickLog::class.java, MenuLog::class.java
             )
-            .logType(
-                logType = PeriodicLog::class.java,
-                filters = listOf(AddTimeFilter()),
-                outputs = listOf(
-                    LogcatOutput(),
-                    PurgeableLogcatWarningBufferedOutput("logcat_warning")
-                )
+            .output(
+                PurgeableLogcatWarningBufferedOutput("logcat_warning"),
+                PeriodicLog::class.java
             )
             .build()
     }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 ext.publication = [:]
 ext.publication.version = [
         'major': '1',
-        'minor': '2',
+        'minor': '4',
         'patch': '0',
 ]
 ext.publication.versionName = "${publication.version.major}.${publication.version.minor}.${publication.version.patch}"

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 ext.publication = [:]
 ext.publication.version = [
         'major': '1',
-        'minor': '3',
+        'minor': '2',
         'patch': '0',
 ]
 ext.publication.versionName = "${publication.version.major}.${publication.version.minor}.${publication.version.patch}"

--- a/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
+++ b/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
@@ -52,10 +52,9 @@ class PureeLogger private constructor(
     private val registeredLogs: Map<Class<out PureeLog>, Configuration>,
     private val bufferedOutputs: List<PureeBufferedOutput>
 ) {
-    private val scope: CoroutineScope =
-        CoroutineScope(dispatcher + CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, "Exception thrown", throwable)
-        })
+    private val scope: CoroutineScope = CoroutineScope(dispatcher + CoroutineExceptionHandler { _, throwable ->
+        Log.e(TAG, "Exception thrown", throwable)
+    })
     private var isResumed: Boolean = false
 
     init {
@@ -226,7 +225,7 @@ class PureeLogger private constructor(
          * [PureeOutput] should be registered and duplicates are ignored.
          * @param logTypes The log types of the objects that will be sent to the [PureeOutput].
          */
-        fun output(output: PureeOutput, vararg logTypes: Class<out PureeLog>): Builder {
+        fun output(output: PureeOutput,vararg logTypes: Class<out PureeLog>): Builder {
             if (output is PureeBufferedOutput) {
                 if (output.uniqueId in outputIds) {
                     throw IllegalArgumentException("Cannot register another PureeBufferedOutput with uniqueId: ${output.uniqueId}.")
@@ -239,24 +238,6 @@ class PureeLogger private constructor(
             logTypes.forEach {
                 configuredLogs.getOrPut(it, { Configuration() }).outputs.add(output)
             }
-
-            return this
-        }
-
-        /**
-         * Registers a log type and associate it with [PureeFilter] and [PureeOutput].
-         *
-         * @param logType The log type to be registered.
-         * @param filters The [PureeFilter]s to use for the log type.
-         * @param outputs The [PureeOutput]s that will emit this log type.
-         */
-        fun logType(
-            logType: Class<out PureeLog>,
-            filters: List<PureeFilter>,
-            outputs: List<PureeOutput>
-        ): Builder {
-            filters.forEach { filter(it, logType) }
-            outputs.forEach { output(it, logType) }
 
             return this
         }

--- a/puree/src/sharedTest/java/com/cookpad/puree/kotlin/PureeLoggerIntegrationTest.kt
+++ b/puree/src/sharedTest/java/com/cookpad/puree/kotlin/PureeLoggerIntegrationTest.kt
@@ -58,14 +58,17 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@FilterTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = listOf(object : PureeFilter {
+                filter(
+                    object : PureeFilter {
                         override fun applyFilter(log: JSONObject): JSONObject = log.apply {
                             put("filter1", "test_value")
                         }
-                    }),
-                    outputs = listOf(output)
+                    },
+                    SampleLog::class.java
+                )
+                output(
+                    output,
+                    SampleLog::class.java
                 )
             }.build()
 
@@ -133,21 +136,25 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@FilterTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = listOf(
-                        object : PureeFilter {
-                            override fun applyFilter(log: JSONObject): JSONObject = log.apply {
-                                put("filter1", "test_value")
-                            }
-                        },
-                        object : PureeFilter {
-                            override fun applyFilter(log: JSONObject): JSONObject = log.apply {
-                                put("filter2", "test_value")
-                            }
+                filter(
+                    object : PureeFilter {
+                        override fun applyFilter(log: JSONObject): JSONObject = log.apply {
+                            put("filter1", "test_value")
                         }
-                    ),
-                    outputs = listOf(output)
+                    },
+                    SampleLog::class.java
+                )
+                filter(
+                    object : PureeFilter {
+                        override fun applyFilter(log: JSONObject): JSONObject = log.apply {
+                            put("filter2", "test_value")
+                        }
+                    },
+                    SampleLog::class.java
+                )
+                output(
+                    output,
+                    SampleLog::class.java
                 )
             }.build()
 
@@ -176,22 +183,25 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@FilterTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = listOf(
-                        object : PureeFilter {
-                            override fun applyFilter(log: JSONObject): JSONObject = log.apply {
-                                put("filter1", "test_value")
-                            }
-                        },
-                        object : PureeFilter {
-                            override fun applyFilter(log: JSONObject): JSONObject =
-                                JSONObject().apply {
-                                    put("filter2", "test_value")
-                                }
+                filter(
+                    object : PureeFilter {
+                        override fun applyFilter(log: JSONObject): JSONObject = log.apply {
+                            put("filter1", "test_value")
                         }
-                    ),
-                    outputs = listOf(output)
+                    },
+                    SampleLog::class.java
+                )
+                filter(
+                    object : PureeFilter {
+                        override fun applyFilter(log: JSONObject): JSONObject = JSONObject().apply {
+                            put("filter2", "test_value")
+                        }
+                    },
+                    SampleLog::class.java
+                )
+                output(
+                    output,
+                    SampleLog::class.java
                 )
             }.build()
 
@@ -241,10 +251,13 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@OutputTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = emptyList(),
-                    outputs = listOf(output1, output2)
+                output(
+                    output1,
+                    SampleLog::class.java
+                )
+                output(
+                    output2,
+                    SampleLog::class.java
                 )
             }.build()
 
@@ -302,10 +315,13 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@OutputTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = emptyList(),
-                    outputs = listOf(outputEvery1s, outputEvery2s)
+                output(
+                    outputEvery1s,
+                    SampleLog::class.java
+                )
+                output(
+                    outputEvery2s,
+                    SampleLog::class.java
                 )
             }.build()
 
@@ -353,10 +369,13 @@ class PureeLoggerIntegrationTest {
             ).apply {
                 dispatcher = coroutineDispatcher
                 clock = this@OutputTests.clock
-                logType(
-                    logType = SampleLog::class.java,
-                    filters = emptyList(),
-                    outputs = listOf(outputEvery5s, outputEvery10s)
+                output(
+                    outputEvery5s,
+                    SampleLog::class.java
+                )
+                output(
+                    outputEvery10s,
+                    SampleLog::class.java
                 )
             }.build()
 


### PR DESCRIPTION
Reverts cookpad/puree-kotlin#5

Revert because of problems using `logType()` with the same output instance.