### PR TITLE
Use SupervisorJob for the coroutine scope managed by PureeLogger

### DIFF
--- a/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
+++ b/puree/src/main/java/com/cookpad/puree/kotlin/PureeLogger.kt
@@ -12,6 +12,7 @@ import com.cookpad.puree.kotlin.store.PureeLogStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import java.time.Clock
@@ -52,7 +53,7 @@ class PureeLogger private constructor(
     private val registeredLogs: Map<Class<out PureeLog>, Configuration>,
     private val bufferedOutputs: List<PureeBufferedOutput>
 ) {
-    private val scope: CoroutineScope = CoroutineScope(dispatcher + CoroutineExceptionHandler { _, throwable ->
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher + CoroutineExceptionHandler { _, throwable ->
         Log.e(TAG, "Exception thrown", throwable)
     })
     private var isResumed: Boolean = false


### PR DESCRIPTION
In this PR, I try to fix a problem which is all job will not work after force flush fails.

As I mentioned in the issue #7, the reason why issue occurred is the coroutine scope managed by PureeLogger uses a Job, not a SupervisorJob because we didn't specify the type of Job.
Therefore, I have specified SupervisorJob for the coroutine scope managed by PureeLogger.

close #7 